### PR TITLE
Condition Signals

### DIFF
--- a/src/main/scala/reactor/BlockingEventQueue.scala
+++ b/src/main/scala/reactor/BlockingEventQueue.scala
@@ -4,6 +4,7 @@
 
 package reactor
 
+import java.util.concurrent.locks.{Condition, ReentrantLock}
 import scala.collection.mutable.Queue
 import reactor.api.Event
 
@@ -14,58 +15,41 @@ final class BlockingEventQueue[T](private val capacity: Int) {
     throw new IllegalArgumentException("Capacity must be positive")
   }
 
-  val queue = Queue[Event[T]]() // store events in a Java queue
+  private val queue = Queue[Event[T]]() // store events in a Java queue
+  private val lock = new ReentrantLock() // lock for the queue
+  private val notFull = lock.newCondition() // condition for the queue not being full
+  private val notEmpty = lock.newCondition() // condition for the queue not being empty
 
   @throws[InterruptedException]
   def enqueue[U <: T](e: Event[U]): Unit = {
     if (e == null) { // ensure that the passed object is not null
       return
     }
-    synchronized {
-      try {
-        while (queue.size >= capacity) { // cannot enqueu while the queue is full
-          if (Thread.interrupted()) { // interrupt check during the wait
-            throw new InterruptedException()
-          }
-          wait()
-        }
-        if (Thread.interrupted()) { // interrupt check before the invocation
-          throw new InterruptedException()
-        }
-        queue += e
-          .asInstanceOf[Event[T]] // casting required for type conformance
-        notifyAll()
-      } catch {
-        case e: InterruptedException => {
-          Thread.currentThread().interrupt() // restore the interrupted status
-          throw e
-        }
+    lock.lockInterruptibly() // lock the queue. May throw InterruptedException
+    try {
+      while (queue.size >= capacity) { // cannot enqueu while the queue is full
+        notFull.await() // wait until the queue may be not full. May throw InterruptedException
       }
+      queue += e
+        .asInstanceOf[Event[T]] // casting required for type conformance
+      notEmpty.signal() // signal that the queue may not be empty
+    } finally {
+      lock.unlock() // unlock the queue.
     }
   }
 
   @throws[InterruptedException]
   def dequeue: Event[T] = {
-    synchronized {
-      try {
-        while (queue.size == 0) {
-          if (Thread.interrupted()) { // interrupt check during the wait
-            throw new InterruptedException()
-          }
-          wait()
-        }
-        if (Thread.interrupted()) { // interrupt check before the invocation
-          throw new InterruptedException()
-        }
-        val dequeuedElement = queue.dequeue()
-        notifyAll()
-        return dequeuedElement
-      } catch {
-        case e: InterruptedException => {
-          Thread.currentThread().interrupt() // restore the interrupted status
-          throw e
-        }
+    lock.lockInterruptibly() // lock the queue. May throw InterruptedException
+    try {
+      while (queue.size == 0) {
+        notEmpty.await() // wait until the queue may be not empty. May throw InterruptedException
       }
+      val dequeuedElement = queue.dequeue()
+      notFull.signal() // signal that the queue may not be full
+      return dequeuedElement
+    } finally {
+      lock.unlock() // unlock the queue
     }
   }
 
@@ -77,8 +61,11 @@ final class BlockingEventQueue[T](private val capacity: Int) {
   // }
 
   def getSize: Int = {
-    synchronized { // possible race condition for the queue size, hence, need to syncronize
+    lock.lock() // lock the queue
+    try {
       return queue.size
+    } finally {
+      lock.unlock() // unlock the queue
     }
   }
 

--- a/src/main/scala/reactor/BlockingEventQueue.scala
+++ b/src/main/scala/reactor/BlockingEventQueue.scala
@@ -4,7 +4,10 @@
 
 package reactor
 
-import java.util.concurrent.locks.{Condition, ReentrantLock}
+import java.util.concurrent.locks.{
+  Condition,
+  ReentrantLock
+} // use ReentrantLock for better control over the lock vs synchronized or implicit locks
 import scala.collection.mutable.Queue
 import reactor.api.Event
 
@@ -17,8 +20,10 @@ final class BlockingEventQueue[T](private val capacity: Int) {
 
   private val queue = Queue[Event[T]]() // store events in a Java queue
   private val lock = new ReentrantLock() // lock for the queue
-  private val notFull = lock.newCondition() // condition for the queue not being full
-  private val notEmpty = lock.newCondition() // condition for the queue not being empty
+  private val notFull =
+    lock.newCondition() // condition for the queue not being full
+  private val notEmpty =
+    lock.newCondition() // condition for the queue not being empty
 
   @throws[InterruptedException]
   def enqueue[U <: T](e: Event[U]): Unit = {
@@ -28,7 +33,8 @@ final class BlockingEventQueue[T](private val capacity: Int) {
     lock.lockInterruptibly() // lock the queue. May throw InterruptedException
     try {
       while (queue.size >= capacity) { // cannot enqueu while the queue is full
-        notFull.await() // wait until the queue may be not full. May throw InterruptedException
+        notFull
+          .await() // wait until the queue may be not full. May throw InterruptedException
       }
       queue += e
         .asInstanceOf[Event[T]] // casting required for type conformance
@@ -43,7 +49,8 @@ final class BlockingEventQueue[T](private val capacity: Int) {
     lock.lockInterruptibly() // lock the queue. May throw InterruptedException
     try {
       while (queue.size == 0) {
-        notEmpty.await() // wait until the queue may be not empty. May throw InterruptedException
+        notEmpty
+          .await() // wait until the queue may be not empty. May throw InterruptedException
       }
       val dequeuedElement = queue.dequeue()
       notFull.signal() // signal that the queue may not be full


### PR DESCRIPTION
Use condition signal() instead of notifyAll(). Instead of notifying all dequeue waits and enqueue waits when dequeued, the dequeue method now wakes up a single enqueue method through a condition signal.